### PR TITLE
added aro-azurefiles

### DIFF
--- a/charts/aro-pull-secret/values.yaml
+++ b/charts/aro-pull-secret/values.yaml
@@ -1,3 +1,0 @@
-# copy this from https://console.redhat.com/openshift/downloads -> Tokens -> Pull secret
-
-pullSecret: '{"auths":{"cloud.openshift.com":{...}}'


### PR DESCRIPTION
- Added ARO Azure Files Helm Chart for enable Azure Files as StorageClass in ARO
- Tested in ARO cluster 4.10
- Documented within the Readme.md of the helm chart
- Pending to generate a mobb.ninja aro azure files post

![azure-files](https://user-images.githubusercontent.com/5543225/214275444-0d787060-b857-4e91-abd8-1770474b8853.png)
