### PR TITLE
[ocp-proxy-api] Adding LB Source Ranges to restrict access at SG level

### DIFF
--- a/charts/ocp-proxy-api/Chart.yaml
+++ b/charts/ocp-proxy-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ocp-proxy-api
 description: A Helm chart for Kubernetes to create and manage an nginx proxy for OCP API/Console
 type: application
-version: 0.1.1
+version: 0.1.2
 home: "https://rh-mobb.github.io/helm-charts/"
 maintainers:
   - name: rh-mobb

--- a/charts/ocp-proxy-api/templates/service.yaml
+++ b/charts/ocp-proxy-api/templates/service.yaml
@@ -22,5 +22,5 @@ spec:
     {{- include "ocp-proxy-api.selectorLabels" . | nindent 4 }}
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-      {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/ocp-proxy-api/templates/service.yaml
+++ b/charts/ocp-proxy-api/templates/service.yaml
@@ -20,3 +20,7 @@ spec:
       name: ingress
   selector:
     {{- include "ocp-proxy-api.selectorLabels" . | nindent 4 }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/ocp-proxy-api/values.yaml
+++ b/charts/ocp-proxy-api/values.yaml
@@ -47,6 +47,8 @@ service:
   type: LoadBalancer
   port: 80
   loadBalancerSourceRanges: []
+    # - 192.168.1.0/24
+    # - 10.1.1.0/24
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/ocp-proxy-api/values.yaml
+++ b/charts/ocp-proxy-api/values.yaml
@@ -46,6 +46,7 @@ podAnnotations: {}
 service:
   type: LoadBalancer
   port: 80
+  loadBalancerSourceRanges: []
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
More info on the `loadBalancerSourceRanges` here: https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support

Feature tested in ROSA and found to be working - i.e.: AWS Security Groups updated correctly 

CC: @paulczar 