### PR TITLE
[ocp-proxy-api] Making Service Ports configurable

### DIFF
--- a/charts/ocp-proxy-api/Chart.yaml
+++ b/charts/ocp-proxy-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ocp-proxy-api
 description: A Helm chart for Kubernetes to create and manage an nginx proxy for OCP API/Console
 type: application
-version: 0.1.2
+version: 0.1.3
 home: "https://rh-mobb.github.io/helm-charts/"
 maintainers:
   - name: rh-mobb

--- a/charts/ocp-proxy-api/templates/service.yaml
+++ b/charts/ocp-proxy-api/templates/service.yaml
@@ -9,15 +9,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   externalTrafficPolicy: Local
+  {{- with .Values.service.ports }}
   ports:
-    - port: 6443
-      targetPort: https
-      protocol: TCP
-      name: api
-    - port: 443
-      targetPort: https
-      protocol: TCP
-      name: ingress
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "ocp-proxy-api.selectorLabels" . | nindent 4 }}
   {{- with .Values.service.loadBalancerSourceRanges }}

--- a/charts/ocp-proxy-api/values.yaml
+++ b/charts/ocp-proxy-api/values.yaml
@@ -46,6 +46,15 @@ podAnnotations: {}
 service:
   type: LoadBalancer
   port: 80
+  ports:
+    - port: 6443
+      targetPort: https
+      protocol: TCP
+      name: api
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: ingress
   loadBalancerSourceRanges: []
     # - 192.168.1.0/24
     # - 10.1.1.0/24


### PR DESCRIPTION
Moving the k8s service ports configuration to the values file to make it easier to customize exposed ports. 

CC @paulczar 