### PR TITLE
Removing incompatible keepalive from OCP API Proxy

### DIFF
--- a/charts/ocp-proxy-api/templates/configmap.yaml
+++ b/charts/ocp-proxy-api/templates/configmap.yaml
@@ -42,11 +42,9 @@ data:
         }
         upstream api_backend {
           server apiserver.openshift-kube-apiserver:443;
-          keepalive {{ .Values.keepalive.connections }};
         }
         upstream ingress_backend {
           server {{ .Values.ocp.ingressLB }}:443;
-          keepalive {{ .Values.keepalive.connections }};
         }
 
         server {
@@ -66,14 +64,6 @@ data:
 
             proxy_pass   $name;
             
-            # Setting these keepalive parameters based on official docs.
-            # This avoids closing each connection and hence avoids exhausting the available resources
-            # https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
-            #   and here:
-            # https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-
             ssl_preread on;
         }
     }

--- a/charts/ocp-proxy-api/values.yaml
+++ b/charts/ocp-proxy-api/values.yaml
@@ -84,7 +84,3 @@ tolerations: []
 
 affinity: {}
 
-keepalive:
-  # A good starting point for 'connections' is to set this to "(replicaCount * 2) + replicaCount"
-  # e.g.: (1 x 2) + 1 = 3
-  connections: 3


### PR DESCRIPTION
Reverting changes introduced by #58 since it's incompatible with the ngnix's `stream` module