### PR TITLE
Updated default storageclass to managed-csi from managed-premium

### DIFF
--- a/charts/aro-clf-blob/Chart.yaml
+++ b/charts/aro-clf-blob/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aro-clf-blob
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
+version: 0.1.3
 home: https://github.com/rh-mobb/helm-charts
 maintainers:
   - name: paulczar

--- a/charts/aro-clf-blob/values.yaml
+++ b/charts/aro-clf-blob/values.yaml
@@ -11,4 +11,4 @@ clf:
   audit: false
 
 lokiStack:
-  storageClassName: managed-premium
+  storageClassName: managed-csi


### PR DESCRIPTION
Updating the aro-clf-blob helm chart to use managed-csi storage class, as that is now the default in ARO.